### PR TITLE
Fix broken specs

### DIFF
--- a/spec/mongify/database/table_spec.rb
+++ b/spec/mongify/database/table_spec.rb
@@ -191,7 +191,7 @@ describe Mongify::Database::Table do
     before(:each) do
       @table = Mongify::Database::Table.new('users')
       @table.column "permission"
-      @table.before_save do |row|
+      @table.before_save do |row, _|
         row.admin = row.delete('permission').to_i > 50
       end
     end


### PR DESCRIPTION
Hi Anlek

I've been migrating legacy site to Rails and MongoDB. Mongify is great help to me, thanks!

However I've encountered a few bugs. I started working in my fork by fixing broken specs. I quickly found the issue, in spec setup before_save callback was expecting only one argument.  I see you added parent row to before_save callback call. You probably forgot to run your tests.
