### PR TITLE
Fix translation process when embedding multiple objects

### DIFF
--- a/features/process.feature
+++ b/features/process.feature
@@ -12,7 +12,8 @@ Feature: Processing a translation
   And there should be 3 posts in mongodb
   And the first post's user_id should be first user
   And there should be 0 comments in mongodb
-  And the first post should have 1 comment
+  And the post with title "First Post" should have 1 comment
+  And the post with title "Second Post" should have 2 comments
   
   Scenario: Processing while modifying embedding parent.
   Given a database exists

--- a/features/step_definitions/mongo_steps.rb
+++ b/features/step_definitions/mongo_steps.rb
@@ -10,6 +10,6 @@ Then /^the (first|sencond|third) (.+)'s (.+) should be (first|second|thrid) (.+)
   DatabaseGenerator.mongo_connection.db[collection.pluralize].find.to_a.send(collection_place.to_sym)[field].should == DatabaseGenerator.mongo_connection.db[target.pluralize].find.to_a.send(target_place)['_id']
 end
 
-Then /^the (first|sencond|third) (.+) should have (\d+) (.+)$/ do |collection_place, collection, count, target|
-  DatabaseGenerator.mongo_connection.db[collection.pluralize].find.to_a.send(collection_place.to_sym)[target.pluralize].count == count
+Then /^the (.+) with (.+) "(.+)" should have (\d+) (.+)$/ do |collection, find_by, find_value, count, target|
+  DatabaseGenerator.mongo_connection.find_one(collection.pluralize, { find_by => find_value })[target.pluralize].count.should == count.to_i
 end

--- a/lib/mongify/translation/process.rb
+++ b/lib/mongify/translation/process.rb
@@ -63,6 +63,7 @@ module Mongify
             row, parent_row = t.translate(row, target_row)
             parent_row ||= {}
             parent_row.delete("_id")
+            parent_row.delete(t.name.to_s)
             #puts "parent_row = #{parent_row.inspect}", "---"
             row.delete(t.embed_on)
             row.merge!(fetch_reference_ids(t, row))

--- a/spec/mongify/translation/process_spec.rb
+++ b/spec/mongify/translation/process_spec.rb
@@ -150,6 +150,12 @@ describe Mongify::Translation::Process do
           @no_sql_connection.should_receive(:update).with("posts", 500, {"$addToSet"=>{"preferences"=>{}}, "$set" => {"email"=>"true"}})
           @translation.send(:copy_embedded_tables)
         end
+        it "should not set embedded attribute in parent" do
+          @embed_table = mock(:translate => [{'first_name' => 'joe'}, {'email' => 'true', 'comments' => [{'first_name' => 'bob'}]}], :name => 'comments', :sql_name => 'comments', :embedded? => true, :embed_on => 'post_id', :embed_in => 'posts', :embedded_as_object? => false)
+          @translation.stub(:tables).and_return([@target_table, @embed_table])
+          @no_sql_connection.should_receive(:update).with("posts", 500, {"$addToSet" => {"comments" => {"first_name" => "joe"}}, "$set" => {"email" => "true"}})
+          @translation.send(:copy_embedded_tables)
+        end
       end
     end
     


### PR DESCRIPTION
I've encountered an issue when embedding multiple objects.

The problem is embedded object is added by `$addToSet` but old objects are also saved with parent by `$set` operation. Like this:

```
"$addToSet" => { "comments" => { "body" => "new comment" } }, "$set" => { "comments" => [{"body" => "previous comment"}]}
```

This causes `$set` to override `$addToSet` operation and you end up with only the first object you embedded.

I've added tests that covers this issue.
