### PR TITLE
Enable fetch_reference_ids to fetch arrays of IDs

### DIFF
--- a/lib/mongify/translation/process.rb
+++ b/lib/mongify/translation/process.rb
@@ -130,7 +130,15 @@ module Mongify
       def fetch_reference_ids(table, row)
         attributes = {}
         table.reference_columns.each do |c|
-          new_id = no_sql_connection.get_id_using_pre_mongified_id(c.references.to_s, row[c.name.to_s])
+          new_id = nil
+          if row[c.name.to_s].is_a?(Array)
+            new_id = []
+            row[c.name.to_s].each do |old_id|
+              new_id << no_sql_connection.get_id_using_pre_mongified_id(c.references.to_s, old_id)
+            end
+          else
+            new_id = no_sql_connection.get_id_using_pre_mongified_id(c.references.to_s, row[c.name.to_s])
+          end
           attributes.merge!(c.name => new_id) unless new_id.nil?
         end
         attributes

--- a/spec/mongify/translation/process_spec.rb
+++ b/spec/mongify/translation/process_spec.rb
@@ -68,6 +68,17 @@ describe Mongify::Translation::Process do
       @no_sql_connection.should_receive(:get_id_using_pre_mongified_id).with('users', 1).once.and_return(500)
       @translation.send(:fetch_reference_ids, @table, {'user_id' => 1}).should == {'user_id' => 500}
     end
+
+    it "should get correct information for arrays" do
+      @no_sql_connection = mock()
+      @translation.stub(:no_sql_connection).and_return(@no_sql_connection)
+      @table = mock(:translate => {}, :name => 'users', :embedded? => false)
+      @column = mock(:name => 'user_ids', :references => 'users')
+      @table.stub(:reference_columns).and_return([@column])
+      @no_sql_connection.should_receive(:get_id_using_pre_mongified_id).with('users', 1).once.and_return(500)
+      @no_sql_connection.should_receive(:get_id_using_pre_mongified_id).with('users', 2).once.and_return(501)
+      @translation.send(:fetch_reference_ids, @table, {'user_ids' => [1, 2]}).should == {'user_ids' => [500, 501]}
+    end
   end
   
   context "processing actions" do


### PR DESCRIPTION
`fetch_reference_ids` should also find the mongified ids if a reference-key column contains an array of IDs. It basically allows to use columns like this:

``` ruby
  column "user_ids", :array, :references => "users"
```

I needed this for a private project but maybe you can merge it.
