### PR TITLE
Make MySQL custom port work

### DIFF
--- a/lib/mongify/database/base_connection.rb
+++ b/lib/mongify/database/base_connection.rb
@@ -9,6 +9,8 @@ module Mongify
       REQUIRED_FIELDS = %w{host}
       # List of all the available fields to make up a connection
       AVAILABLE_FIELDS = %w{adapter host username password database socket port encoding}
+      # List of all fields that should be forced to a string
+      STRING_FIELDS = %w{adapter}
       
       def initialize(options=nil)
         if options
@@ -56,7 +58,8 @@ module Mongify
         super(method)
       end
       
-      # Building set and/or return functions for AVAILABLE_FIELDS
+      # Building set and/or return functions for AVAILABLE_FIELDS.
+      # STRING_FIELDS are forced into string.
       # Example:
       # 
       #   def host(value=nil)
@@ -67,9 +70,16 @@ module Mongify
       def method_missing(method, *args)
         method_name = method.to_s
         if AVAILABLE_FIELDS.include?(method_name.to_s)
+
+          if STRING_FIELDS.include?(method_name.to_s)
+            assignment = "@#{method_name} = value.to_s"
+          else
+            assignment = "@#{method_name} = value"
+          end
+
           class_eval <<-EOF
                           def #{method_name}(value=nil)
-                            @#{method_name} = value.to_s unless value.nil?
+                            #{assignment} unless value.nil?
                             @#{method_name}
                           end
                         EOF

--- a/spec/mongify/database/base_connection_spec.rb
+++ b/spec/mongify/database/base_connection_spec.rb
@@ -47,6 +47,11 @@ describe Mongify::Database::BaseConnection do
     @base_connection.adapter.should == 'sqlite'
   end
 
+  it "should leave port argument as an integer" do
+    @base_connection.port 3333
+    @base_connection.port.should == 3333
+  end
+
   context "hash" do
     before(:each) do
       @adapter = 'baseDB'


### PR DESCRIPTION
Hi,

I took a look into the code and found that all connection fields are forced into String. This does not work with the Active Record MySQL Adapter, since it requires Integer for the port number. I tried to fix it by introducing a `STRING_FIELDS` variable that includes all fields that should be forced into Strings (currently only `adapter`). I added a test for the port number, all other tests are still passing.

This should fix #20.

I know it is not the prettiest solution, so suggestions for improvement are very welcome.

Thanks!
