### PR TITLE
Add primary_key option to :embed_in table

### DIFF
--- a/lib/mongify/database/table.rb
+++ b/lib/mongify/database/table.rb
@@ -160,6 +160,11 @@ module Mongify
         (@options['on'] || "#{@options['embed_in'].to_s.singularize}_id").to_s
       end
       
+      # Return the primary_ky
+      def primary_key
+        @options['primary_key'].to_s unless @options['primary_key'].nil?
+      end
+      
       # Used to save a block to be ran after the row has been processed but before it's saved to the no sql database
       def before_save(&block)
         @before_save_callback = block

--- a/lib/mongify/translation/process.rb
+++ b/lib/mongify/translation/process.rb
@@ -57,7 +57,8 @@ module Mongify
           rows = sql_connection.select_rows(t.sql_name)
           Mongify::Status.publish('copy_embedded', :size => rows.count, :name => "Embedding #{t.name}", :action => 'add')
           rows.each do |row|
-            target_row = no_sql_connection.find_one(t.embed_in, {:pre_mongified_id => row[t.embed_on]})
+            primary_key = t.primary_key || :pre_mongified_id
+            target_row = no_sql_connection.find_one(t.embed_in, {primary_key => row[t.embed_on]})
             next unless target_row.present?
             # puts "target_row = #{target_row.inspect}", "---"
             row, parent_row = t.translate(row, target_row)

--- a/spec/mongify/database/table_spec.rb
+++ b/spec/mongify/database/table_spec.rb
@@ -185,6 +185,18 @@ describe Mongify::Database::Table do
         Mongify::Database::Table.new('comments', :embed_in => 'posts').embed_on.should == 'post_id'
       end
     end
+
+    context "primary_key" do
+      it "should return primary_key option" do
+        Mongify::Database::Table.new('comments', :embed_in => 'posts', :on => 'post_id', :primary_key => 'unique_id').primary_key.should == 'unique_id'
+      end
+      it "should be nil when not defined" do
+        Mongify::Database::Table.new('comments', :embed_in => 'posts', :on => 'post_id').primary_key.should be_nil
+      end
+      it "should be nil when not embedded table" do
+        Mongify::Database::Table.new('users').primary_key.should be_nil
+      end
+    end
   end
   
   context "before_save" do

--- a/spec/mongify/translation/process_spec.rb
+++ b/spec/mongify/translation/process_spec.rb
@@ -109,11 +109,11 @@ describe Mongify::Translation::Process do
         @translation.send(:copy_data)
       end
     end
-    
+
     context "copy_embed_tables" do
       before(:each) do
         @target_table = mock(:name => 'posts', :embedded? => false, :sql_name => 'posts')
-        @embed_table = mock(:translate => {}, :name => 'comments', :embedded? => true, :embed_on => 'post_id', :embed_in => 'posts', :embedded_as_object? => false, :sql_name => 'comments')
+        @embed_table = mock(:translate => {}, :name => 'comments', :embedded? => true, :embed_on => 'post_id', :embed_in => 'posts', :embedded_as_object? => false, :sql_name => 'comments', :primary_key => nil)
         @no_sql_connection.stub(:find_one).and_return({'_id' => 500})
         @translation.stub(:tables).and_return([@target_table, @embed_table])
         @translation.stub(:fetch_reference_ids).and_return({})
@@ -125,45 +125,52 @@ describe Mongify::Translation::Process do
         @translation.send(:copy_embedded_tables)
       end
       it "should remove the pre_mongified_id before embedding" do
-        @embed_table = mock(:translate => {'first_name' => 'bob', 'pre_mongified_id' => 1}, :name => 'comments', :sql_name => 'comments', :embedded? => true, :embed_on => 'post_id', :embed_in => 'posts', :embedded_as_object? => false)
+        @embed_table = mock(:translate => {'first_name' => 'bob', 'pre_mongified_id' => 1}, :name => 'comments', :sql_name => 'comments', :embedded? => true, :embed_on => 'post_id', :embed_in => 'posts', :embedded_as_object? => false, :primary_key => nil)
         @translation.stub(:tables).and_return([@target_table, @embed_table])
         @no_sql_connection.should_receive(:update).with("posts", 500, {"$addToSet"=>{"comments"=>{'first_name' => 'bob'}}})
         @translation.send(:copy_embedded_tables)
       end
       it "should remove the parent_id from the embedding row" do
-        @embed_table = mock(:translate => {'first_name' => 'bob', 'post_id' => 1}, :name => 'comments', :sql_name => 'comments', :embedded? => true, :embed_on => 'post_id', :embed_in => 'posts', :embedded_as_object? => false)
+        @embed_table = mock(:translate => {'first_name' => 'bob', 'post_id' => 1}, :name => 'comments', :sql_name => 'comments', :embedded? => true, :embed_on => 'post_id', :embed_in => 'posts', :embedded_as_object? => false, :primary_key => nil)
         @translation.stub(:tables).and_return([@target_table, @embed_table])
         @no_sql_connection.should_receive(:update).with("posts", 500, {"$addToSet"=>{"comments"=>{'first_name' => 'bob'}}})
         @translation.send(:copy_embedded_tables)
       end
       it "should call $addToSet on update of an embed_as_object table" do
-        @embed_table = mock(:translate => {'first_name' => 'bob', 'post_id' => 1}, :name => 'comments', :sql_name => 'comments', :embedded? => true, :embed_on => 'post_id', :embed_in => 'posts', :embedded_as_object? => true)
+        @embed_table = mock(:translate => {'first_name' => 'bob', 'post_id' => 1}, :name => 'comments', :sql_name => 'comments', :embedded? => true, :embed_on => 'post_id', :embed_in => 'posts', :embedded_as_object? => true, :primary_key => nil)
         @translation.stub(:tables).and_return([@target_table, @embed_table])
         @no_sql_connection.should_receive(:update).with("posts", 500, {"$set"=>{"comments"=>{'first_name' => 'bob'}}})
         @translation.send(:copy_embedded_tables)
       end
       it "should allow rename of table" do
-        @embed_table = mock(:translate => {'first_name' => 'bob', 'post_id' => 1}, :name => 'notes', :sql_name => 'comments', :embedded? => true, :embed_on => 'post_id', :embed_in => 'posts', :embedded_as_object? => true)
+        @embed_table = mock(:translate => {'first_name' => 'bob', 'post_id' => 1}, :name => 'notes', :sql_name => 'comments', :embedded? => true, :embed_on => 'post_id', :embed_in => 'posts', :embedded_as_object? => true, :primary_key => nil)
         @translation.stub(:tables).and_return([@target_table, @embed_table])
         @no_sql_connection.should_receive(:update).with("posts", 500, {"$set"=>{"notes"=>{'first_name' => 'bob'}}})
         @translation.send(:copy_embedded_tables)
       end
-      
+      it "should allow different primary_key" do
+        @embed_table = mock(:translate => {'first_name' => 'bob', 'post_id' => 1}, :name => 'notes', :sql_name => 'comments', :embedded? => true, :embed_on => 'post_id', :embed_in => 'posts', :embedded_as_object? => true, :primary_key => 'uuid')
+        @translation.stub(:tables).and_return([@target_table, @embed_table])
+        @no_sql_connection.should_receive(:find_one).with("posts", {"uuid" => nil}).and_return({"_id" => 500})
+        @no_sql_connection.should_receive(:update).with("posts", 500, {"$set"=>{"notes"=>{'first_name' => 'bob'}}})
+        @translation.send(:copy_embedded_tables)
+      end
+
       context "parent modification" do
         it "should work with embedded objects" do
-          @embed_table = mock(:translate => [{}, {'email' => 'true'}], :name => 'preferences', :sql_name => 'preferences', :embedded? => true, :embed_on => 'post_id', :embed_in => 'posts', :embedded_as_object? => true)
+          @embed_table = mock(:translate => [{}, {'email' => 'true'}], :name => 'preferences', :sql_name => 'preferences', :embedded? => true, :embed_on => 'post_id', :embed_in => 'posts', :embedded_as_object? => true, :primary_key => nil)
           @translation.stub(:tables).and_return([@target_table, @embed_table])
           @no_sql_connection.should_receive(:update).with("posts", 500, {"$set"=>{"preferences"=>{}, "email"=>"true"}})
           @translation.send(:copy_embedded_tables)
         end
         it "should work with embedded arrays" do
-          @embed_table = mock(:translate => [{}, {'email' => 'true'}], :name => 'preferences', :sql_name => 'preferences', :embedded? => true, :embed_on => 'post_id', :embed_in => 'posts', :embedded_as_object? => false)
+          @embed_table = mock(:translate => [{}, {'email' => 'true'}], :name => 'preferences', :sql_name => 'preferences', :embedded? => true, :embed_on => 'post_id', :embed_in => 'posts', :embedded_as_object? => false, :primary_key => nil)
           @translation.stub(:tables).and_return([@target_table, @embed_table])
           @no_sql_connection.should_receive(:update).with("posts", 500, {"$addToSet"=>{"preferences"=>{}}, "$set" => {"email"=>"true"}})
           @translation.send(:copy_embedded_tables)
         end
         it "should not set embedded attribute in parent" do
-          @embed_table = mock(:translate => [{'first_name' => 'joe'}, {'email' => 'true', 'comments' => [{'first_name' => 'bob'}]}], :name => 'comments', :sql_name => 'comments', :embedded? => true, :embed_on => 'post_id', :embed_in => 'posts', :embedded_as_object? => false)
+          @embed_table = mock(:translate => [{'first_name' => 'joe'}, {'email' => 'true', 'comments' => [{'first_name' => 'bob'}]}], :name => 'comments', :sql_name => 'comments', :embedded? => true, :embed_on => 'post_id', :embed_in => 'posts', :embedded_as_object? => false, :primary_key => nil)
           @translation.stub(:tables).and_return([@target_table, @embed_table])
           @no_sql_connection.should_receive(:update).with("posts", 500, {"$addToSet" => {"comments" => {"first_name" => "joe"}}, "$set" => {"email" => "true"}})
           @translation.send(:copy_embedded_tables)


### PR DESCRIPTION
This patch allows the embed table to reference a different parent column as primary_key, so relation like these can also be translated: 

```
class Post < ActiveRecord::Base
  has_many :comments, :primary_key => 'unique_title'
end

class Comment < ActiveRecord::Base
  belongs_to :posts, :primary_key => 'unique_title'
end
```
