### PR TITLE
Unset parent_row fields when processing before_save for embedded objects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,8 @@ spec/tmp/*
 .bundle/*
 
 .rvmrc
+.ruby-gemset
+.ruby-version
 
 spec/support/database.yml
 

--- a/features/process.feature
+++ b/features/process.feature
@@ -23,3 +23,12 @@ Feature: Processing a translation
   And there should be 3 users in mongodb
   And the first user's notify_by_email attribute should be true
   And the third user's notify_by_email attribute should be false
+
+  Scenario: Processing while deleting fields from embedding parent
+  Given a database exists
+  And a blank mongodb
+  When I run mongify process spec/files/base_configuration.rb spec/files/deleting_fields_from_embedding_parent_translation.rb
+  Then it succeeds
+  And there should be 3 teams in mongodb
+  And the first team's phone attribute should not be present
+  And the third team's coach's phone attribute should be +1112223334

--- a/features/step_definitions/process_steps.rb
+++ b/features/step_definitions/process_steps.rb
@@ -1,4 +1,14 @@
-Then /^the (first|second|third) (.+)'s (.+) attribute should be (.+)$/ do |collection_place, collection_name, field, value|
+Then /^the (first|second|third) ([^\s]+)'s ([^\s]+) attribute should be (.+)$/ do |collection_place, collection_name, field, value|
   DatabaseGenerator.mongo_connection.db[collection_name.pluralize].
                    find.to_a.send(collection_place.to_sym)[field].to_s.should == value.to_s
+end
+
+Then /^the (first|second|third) ([^\s]+)'s ([^\s]+) attribute should( not)? be present$/ do |collection_place, collection_name, field, negate|
+  DatabaseGenerator.mongo_connection.db[collection_name.pluralize].
+                    find.to_a.send(collection_place.to_sym).has_key?(field).should (negate ? be_false : be_true)
+end
+
+Then /^the (first|second|third) ([^\s]+)'s ([^\s]+)'s ([^\s]+) attribute should be (.+)$/ do |collection_place, collection_name, embedded_name, field, value|
+  DatabaseGenerator.mongo_connection.db[collection_name.pluralize].
+                    find.to_a.send(collection_place.to_sym)[embedded_name][field].to_s.should == value.to_s
 end

--- a/lib/mongify/database/table.rb
+++ b/lib/mongify/database/table.rb
@@ -180,8 +180,13 @@ module Mongify
         parentrow = Mongify::Database::DataRow.new(parent) unless parent.nil?
         datarow = Mongify::Database::DataRow.new(row)
         @before_save_callback.call(datarow, parentrow) unless @before_save_callback.nil?
-        if parentrow            
-          [datarow.to_hash, parentrow.to_hash]
+        if parentrow
+          parentrow_hash = parentrow.to_hash
+          unsets = parent.keys.inject({}) do |unset_keys, key|
+            unset_keys[key] = '1' unless parentrow_hash.has_key?(key)
+            unset_keys
+          end
+          [datarow.to_hash, parentrow_hash, unsets]
         else
           datarow.to_hash
         end

--- a/spec/files/deleting_fields_from_embedding_parent_translation.rb
+++ b/spec/files/deleting_fields_from_embedding_parent_translation.rb
@@ -1,0 +1,19 @@
+table 'teams' do
+  column 'id', :key
+  column 'name', :string
+  column 'phone', :string
+  column 'created_at', :datetime
+  column 'updated_at', :datetime
+end
+
+table 'coaches', :embed_in => 'teams', :as => 'object', :rename_to => 'coach' do
+  column 'id', :key
+  column 'team_id', :integer, :references => "teams"
+  column 'first_name', :string
+  column 'last_name', :string
+  column 'created_at', :datetime
+  column 'updated_at', :datetime
+  before_save do |row, parent_row|
+    row.write_attribute('phone',parent_row.delete('phone'))
+  end
+end

--- a/spec/mongify/database/sql_connection_spec.rb
+++ b/spec/mongify/database/sql_connection_spec.rb
@@ -56,7 +56,7 @@ describe Mongify::Database::SqlConnection do
 
     context "tables" do
       it "should be able to get a list" do
-        sqlite_connection.tables.should =~ ['comments', 'notes', 'posts', 'preferences', 'users']
+        sqlite_connection.tables.should =~ %w(comments notes posts preferences users teams coaches)
       end
     end
 

--- a/spec/mongify/database/table_spec.rb
+++ b/spec/mongify/database/table_spec.rb
@@ -225,12 +225,22 @@ describe Mongify::Database::Table do
       end
     end
     it "should work" do
-      @table.translate({'preferences' => 'yes'}, {}).should == [{}, {'preferences' => 'yes'}]
+      @table.translate({'preferences' => 'yes'}, {}).should == [{}, {'preferences' => 'yes'}, {}]
     end
     it "should return blank hash if parent is unchanged" do
       @table.remove_before_save_filter!
-      @table.translate({'preferences' => "true"}, {}).should == [{'preferences' => "true"}, {}]
+      @table.translate({'preferences' => "true"}, {}).should == [{'preferences' => "true"}, {}, {}]
     end
+    it 'should return a hash containing the keys that have been deleted on the parent row' do
+      @parent_table.column('field_1')
+      @parent_table.column('field_2')
+      @table.before_save do |_, parent|
+        parent.delete('field_1')
+      end
+      @table.translate({'preferences' => 'true'},{'field_1' => 'a', 'field_2' => 'b'}).should ==
+          [{'preferences' => 'true'}, {'field_2' => 'b'}, {'field_1' => '1'}]
+    end
+
   end
   
   

--- a/spec/support/database_generator.rb
+++ b/spec/support/database_generator.rb
@@ -59,6 +59,18 @@ class DatabaseGenerator
       t.text :body
       t.timestamps
     end
+
+    conn.create_table(:teams) do |t|
+      t.string :name
+      t.string :phone
+      t.timestamps
+    end
+
+    conn.create_table(:coaches) do |t|
+      t.integer :team_id
+      t.string :first_name, :last_name
+      t.timestamps
+    end
     
     if include_data
       
@@ -75,7 +87,7 @@ class DatabaseGenerator
       [ 
         {:title => 'First Post', :owner_id => 1, :body => 'First Post Body', :published_at => (Time.now - 2).to_s(:db)},
         {:title => 'Second Post', :owner_id => 1, :body => 'Second Post Body', :published_at => (Time.now - 1).to_s(:db)},
-        {:title => 'Third Post', :owner_id => 2, :body => 'Thrid Post Body', :published_at => (Time.now).to_s(:db)},
+        {:title => 'Third Post', :owner_id => 2, :body => 'Third Post Body', :published_at => (Time.now).to_s(:db)},
       ].each do |v|
         conn.insert("INSERT INTO posts (title, owner_id, body, published_at, created_at, updated_at) 
                     VALUES ('#{v[:title]}', #{v[:owner_id]}, '#{v[:body]}', '#{v[:published_at]}', '#{Time.now.to_s(:db)}', '#{Time.now.to_s(:db)}')")
@@ -85,7 +97,7 @@ class DatabaseGenerator
       [
         {:post_id => 1, :user_id => 1, :body => 'First Comment Body'},
         {:post_id => 2, :user_id => 1, :body => 'Second Comment Body'},
-        {:post_id => 2, :user_id => 2, :body => 'Thrid Comment Body'},
+        {:post_id => 2, :user_id => 2, :body => 'Third Comment Body'},
       ].each do |v|
         conn.insert("INSERT INTO comments (body, post_id, user_id, created_at, updated_at) 
                     VALUES ('#{v[:body]}', #{v[:post_id]}, #{v[:user_id]}, '#{Time.now.to_s(:db)}', '#{Time.now.to_s(:db)}')")
@@ -110,6 +122,26 @@ class DatabaseGenerator
       ].each do |v|
           conn.insert("INSERT INTO notes (user_id, body, notable_id, notable_type, created_at, updated_at) 
                       VALUES (#{v[:user_id]}, '#{v[:body]}', #{v[:notable_id]}, '#{v[:notable_type]}', '#{Time.now.to_s(:db)}', '#{Time.now.to_s(:db)}')")
+      end
+
+      #Teams
+      [
+        {:name => 'Athens Avengers', :phone => '+1122334455'},
+        {:name => 'Berlin Bashers', :phone => '+1234567890'},
+        {:name => 'Copenhagen Crushers', :phone => '+1112223334'}
+      ].each do |v|
+        conn.insert("INSERT INTO teams (name, phone, created_at, updated_at)
+                    VALUES ('#{v[:name]}', '#{v[:phone]}', '#{Time.now.to_s(:db)}', '#{Time.now.to_s(:db)}')")
+      end
+
+      #Coaches
+      [
+        {:team_id => 1, :first_name => 'Alice', :last_name => 'Adams'},
+        {:team_id => 2, :first_name => 'Bob', :last_name => 'Brown'},
+        {:team_id => 3, :first_name => 'Carl', :last_name => 'Cooper'}
+      ].each do |v|
+        conn.insert("INSERT INTO coaches (team_id, first_name, last_name, created_at, updated_at)
+                    VALUES (#{v[:team_id]}, '#{v[:first_name]}', '#{v[:last_name]}', '#{Time.now.to_s(:db)}', '#{Time.now.to_s(:db)}')")
       end
       
     end

--- a/spec/support/database_output.txt
+++ b/spec/support/database_output.txt
@@ -43,3 +43,20 @@ table "notes" do
 	column "updated_at", :datetime
 end
 
+table "teams" do
+	column "id", :key, :as => :integer
+	column "name", :string
+	column "phone", :string
+	column "created_at", :datetime
+	column "updated_at", :datetime
+end
+
+table "coaches" do
+	column "id", :key, :as => :integer
+	column "team_id", :integer, :references => "teams"
+	column "first_name", :string
+	column "last_name", :string
+	column "created_at", :datetime
+	column "updated_at", :datetime
+end
+


### PR DESCRIPTION
The current code does not allow fields to be delete from the parent row during the before_save callback of an embedded objects. Or rather fields can be deleted from the hash, but they are not "unset" in the database.
Although maybe a rare case, in some 1-to-1 relationships it is useful, when migrating from SQL to Mongo, to push some fields of the parent object to the embedded one.
Together with the code, I added specs to test the new functionality and a new cucumber scenario to the process feature which test the new functionality.

regards,
marco
