### PR TITLE
fix 'uninitialized constant ActiveSupport::Autoload' in some machines

### DIFF
--- a/lib/mongify.rb
+++ b/lib/mongify.rb
@@ -1,6 +1,7 @@
 #
 # Mongify's core functionality
 #
+require 'active_support'
 require 'active_support/core_ext'
 require 'active_record'
 require 'highline'


### PR DESCRIPTION
error:
number_helper.rb:3:in `module:NumberHelper': uninitialized constant ActiveSupport::Autoload (NameError)

related issues:
https://github.com/rails/rails/issues/14664
https://github.com/beeminder/beeminder-gem/issues/10
https://github.com/nulldb/nulldb/issues/38
